### PR TITLE
Remove redundant check and added regex number list

### DIFF
--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -24,8 +24,7 @@ function! s:IsMkdCode(lnum)
 endfunction
 
 function! s:IsLiStart(line)
-    return a:line !~ '^ *\([*-]\)\%( *\1\)\{2}\%( \|\1\)*$' &&
-      \    a:line =~ '^\s*[*+-] \+'
+    return a:line =~ '^\s*\([*+-]\|1.\) \+'
 endfunction
 
 function! s:IsHeaderLine(line)

--- a/test/indent-new-list-item.vader
+++ b/test/indent-new-list-item.vader
@@ -15,21 +15,21 @@ Expect (insert 2 spaces to the head of second item):
     * item2
 
 Given markdown;
-- [ ] item1
+1. item1
 
-Do (new line from the first item of the list and add the second item):
-  A\<Enter>item2
+Do (new line from the first item of the numbered list and add the second item):
+  o1. item2
 
-Expect (insert another list item with the empty check-box automatically):
-  - [ ] item1
-  - [ ] item2
+Expect (insert 2 spaces to the head of second item):
+  1. item1
+    1. item2
 
 Given markdown;
-- [x] item1
+- [ ] item1
 
-Do (new line from the first item of the list and add the second item):
-  A\<Enter>item2
+Do (new line from the first item of the numbered list and add the second item):
+  o- [ ] item2
 
-Expect (insert another list item with the empty check-box automatically):
-  - [x] item1
-  - [ ] item2
+Expect (insert 2 spaces to the head of second item):
+  - [ ] item1
+    - [ ] item2

--- a/test/indent.md
+++ b/test/indent.md
@@ -13,12 +13,13 @@ Following example is horizontal item.
 - - -
 * * *
 
-And list item must be specified space after [*-+].
+And list item must be specified space after [*-+]|(\d+\.).
 Following example is list item.
 
 * foo
 - bar
 + baz
+1. baz
 
 But following example is not list item.
 *foo

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -71,3 +71,33 @@ Do (new line from the first item of the list and add the second item):
 Expect (insert 4 spaces to the head of second item):
   * item1
       * item2
+
+Given markdown;
+1. item1
+
+Do (insert enter with numbered list)
+  A\<cr>item2
+
+Expect (auto insert '1.' and indent level is same)
+  1. item1
+  1. item2
+
+Given markdown;
+- [ ] item1
+
+Do (new line from the first item of the list and add the second item):
+  A\<Enter>item2
+
+Expect (insert another list item with the empty check-box automatically):
+  - [ ] item1
+  - [ ] item2
+
+Given markdown;
+- [x] item1
+
+Do (new line from the first item of the list and add the second item):
+  A\<Enter>item2
+
+Expect (insert another list item with the empty check-box automatically):
+  - [x] item1
+  - [ ] item2


### PR DESCRIPTION
The first regex in the check for list items is redundant and test
doesn't fail if removed. Added `1.` to the regex for lists and tests for
each case.